### PR TITLE
Fix extrusion image in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Part numbers are listed for both square 4040, and rounded 404020 vertical extrus
 #### Note:
 If you choose to use rounded corners, you will need to reuse your frame's existing 2020 vertical extrusions, or purchase a set of them for a scratch build.  The rounded verticals do not require machining, but the 2020 verticals that nest into them will need to have holes drilled to enable securing the rounded piece with blind joints, as shown here.
 
-<img src="Images/404020-1.jpg" alt="drawing" width="200"/>
+![Corner extrusion profile shown from above](Images/404020-1.jpg)
 
 ## Extrusions Based on Standard V2 Build Sizes
 


### PR DESCRIPTION
Somehow an image link in the readme has become invalid, this is a simple PR to fix it.